### PR TITLE
fix scrutinizer python version

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,6 @@
 build:
+  environment:
+    python: 3.6.3
   tests:
     override:
       - pylint-run --rcfile=.pylint.ini


### PR DESCRIPTION
### Summary

Fix scrutinizer configuration, defining python version to 3.6.3
