### PR TITLE
Fixing test case with proportional function

### DIFF
--- a/NiaPy/algorithms/basic/de.py
+++ b/NiaPy/algorithms/basic/de.py
@@ -2,7 +2,7 @@
 import logging
 import math
 
-from numpy import random as rand, argmin, argmax, mean, cos, asarray, append, sin
+from numpy import random as rand, argmin, argmax, mean, cos, asarray, append, sin, isfinite
 from scipy.spatial.distance import euclidean
 
 from NiaPy.algorithms.algorithm import Algorithm, Individual, defaultIndividualInit
@@ -738,7 +738,7 @@ class AgingNpDifferentialEvolution(DifferentialEvolution):
 		"""
 		fpop = asarray([x.f for x in pop])
 		x_b, x_w = pop[argmin(fpop)], pop[argmax(fpop)]
-		avg, npop = mean(fpop), []
+		avg, npop = mean(fpop[isfinite(fpop)]), []
 		for x in pop:
 			x.age += 1
 			Lt = round(self.age(Lt_min=self.Lt_min, Lt_max=self.Lt_max, mu=self.mu, x_f=x.f, avg=avg, x_gw=x_w.f, x_gb=x_b.f))

--- a/NiaPy/algorithms/basic/de.py
+++ b/NiaPy/algorithms/basic/de.py
@@ -1,5 +1,6 @@
 # encoding=utf8
 import logging
+import math
 
 from numpy import random as rand, argmin, argmax, mean, cos, asarray, append, sin
 from scipy.spatial.distance import euclidean
@@ -561,7 +562,8 @@ def proportional(Lt_min, Lt_max, mu, x_f, avg, **args):
 	Returns:
 		int: Age of individual.
 	"""
-	return min(Lt_min + mu * avg / x_f, Lt_max)
+	proportional_result = Lt_max if math.isinf(avg) else Lt_min + mu * avg / x_f
+	return min(proportional_result, Lt_max)
 
 def linear(Lt_min, mu, x_f, x_gw, x_gb, **args):
 	r"""Linear calculation of age of individual.

--- a/NiaPy/tests/test_algorithm.py
+++ b/NiaPy/tests/test_algorithm.py
@@ -313,6 +313,8 @@ class AlgorithmTestCase(TestCase):
 		if a is None or b is None: return
 		for D in self.D:
 			task1, task2 = self.setUpTasks(D, benc, nFES=nFES)
+			# x = a.run(task1) # For debugging purposes
+			# y = b.run(task2) # For debugging purposes
 			q = Queue(maxsize=2)
 			thread1, thread2 = Thread(target=lambda a, t, q: q.put(a.run(t)), args=(a, task1, q)), Thread(target=lambda a, t, q: q.put(a.run(t)), args=(b, task2, q))
 			thread1.start(), thread2.start()

--- a/NiaPy/tests/test_benchmark_functions.py
+++ b/NiaPy/tests/test_benchmark_functions.py
@@ -1,6 +1,6 @@
 # encoding=utf8
 
-from math import pow, isnan
+from math import pow
 from unittest import TestCase
 from numpy import asarray, pi, full, seterr
 from NiaPy.task import Utility
@@ -440,4 +440,4 @@ class TestBenchmarkFunctions(TestCase):
         for size in sizes:
             with self.assertRaises(FloatingPointError):
                     fun(size, full(size, .0))
-            self.assertAlmostEqual(fun(size, full(size, 1.0)), 2.84147098480789650665250232163*size)
+            self.assertAlmostEqual(fun(size, full(size, 1.0)), 2.84147098480789650665250232163 * size)

--- a/NiaPy/tests/test_benchmark_functions.py
+++ b/NiaPy/tests/test_benchmark_functions.py
@@ -2,7 +2,7 @@
 
 from math import pow, isnan
 from unittest import TestCase
-from numpy import asarray, pi, full
+from numpy import asarray, pi, full, seterr
 from NiaPy.task import Utility
 
 
@@ -435,9 +435,9 @@ class TestBenchmarkFunctions(TestCase):
 
         fun = self.assertBounds('infinity', -1, 1)
         self.assertTrue(callable(fun))
-        self.assertTrue(isnan(fun(2, full(2, .0))))
-        self.assertTrue(isnan(fun(10, full(10, .0))))
-        self.assertTrue(isnan(fun(100, full(100, .0))))
-        self.assertAlmostEqual(fun(2, full(2, 1e-4)), .0)
-        self.assertAlmostEqual(fun(10, full(10, 1e-4)), .0)
-        self.assertAlmostEqual(fun(100, full(100, 1e-4)), .0)
+        sizes = [2, 10, 100]
+        seterr('raise')
+        for size in sizes:
+            with self.assertRaises(FloatingPointError):
+                    fun(size, full(size, .0))
+            self.assertAlmostEqual(fun(size, full(size, 1.0)), 2.84147098480789650665250232163*size)

--- a/NiaPy/tests/test_de.py
+++ b/NiaPy/tests/test_de.py
@@ -80,14 +80,14 @@ class ANpDETestCase(AlgorithmTestCase):
 	def setUp(self):
 		AlgorithmTestCase.setUp(self)
 		self.algo = AgingNpDifferentialEvolution
-
-	@skip("Not working")
+	
+	#@skip("Not working")
 	def test_Custom_works_fine(self):
 		de_custom = self.algo(NP=40, F=0.5, CR=0.9, seed=self.seed)
 		de_customc = self.algo(NP=40, F=0.5, CR=0.9, seed=self.seed)
 		AlgorithmTestCase.test_algorithm_run(self, de_custom, de_customc, MyBenchmark())
 
-	@skip("Not working")
+	#@skip("Not working")
 	def test_griewank_works_fine(self):
 		de_griewank = self.algo(NP=10, CR=0.5, F=0.9, seed=self.seed)
 		de_griewankc = self.algo(NP=10, CR=0.5, F=0.9, seed=self.seed)

--- a/NiaPy/tests/test_de.py
+++ b/NiaPy/tests/test_de.py
@@ -80,14 +80,12 @@ class ANpDETestCase(AlgorithmTestCase):
 	def setUp(self):
 		AlgorithmTestCase.setUp(self)
 		self.algo = AgingNpDifferentialEvolution
-	
-	#@skip("Not working")
+
 	def test_Custom_works_fine(self):
 		de_custom = self.algo(NP=40, F=0.5, CR=0.9, seed=self.seed)
 		de_customc = self.algo(NP=40, F=0.5, CR=0.9, seed=self.seed)
 		AlgorithmTestCase.test_algorithm_run(self, de_custom, de_customc, MyBenchmark())
 
-	#@skip("Not working")
 	def test_griewank_works_fine(self):
 		de_griewank = self.algo(NP=10, CR=0.5, F=0.9, seed=self.seed)
 		de_griewankc = self.algo(NP=10, CR=0.5, F=0.9, seed=self.seed)


### PR DESCRIPTION
### Summary

It seems that there exists and error when using proportional function, when avg is calculated, if any population value goes to _infinity_ then at some point the _proportional_ function throws an error because of its inner division. Average should be calculated in any other way skipping these values, as the _proportional_ function needs to do so.

### Other Information

This is my first contribution to the project and should be revised carefully.
I wish to thank the team for letting me participating at it.
