### PR TITLE
Fix detection of two digit Python minor version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,13 @@ import setuptools
 
 
 PACKAGE_NAME = 'niapy'
-MINIMUM_PYTHON_VERSION = '3.6'
+MINIMUM_PYTHON_VERSION = (3,6)
 
 
 def check_python_version():
     """Exit when the Python version is too low."""
-    if sys.version < MINIMUM_PYTHON_VERSION:
-        sys.exit("Python {0}+ is required.".format(MINIMUM_PYTHON_VERSION))
+    if sys.version_info[:2] < MINIMUM_PYTHON_VERSION:
+        sys.exit("Python {}.{}+ is required.".format(*MINIMUM_PYTHON_VERSION))
 
 
 def read_package_variable(key, filename='__init__.py'):


### PR DESCRIPTION
### Summary
NiaPy fails when build with Python 3.10 because it is treated as `3.1` instead of `3.10`. This PR attempts to fix this so version is detected corectly.
~~~~
+ /usr/bin/python3 setup.py build '--executable=/usr/bin/python3 -s'
Python 3.6+ is required.
~~~~
