### PR TITLE
Modify convergence plotting

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -36,3 +36,4 @@ pandoc = "*"
 twine = "*"
 pytest-testmon = "~=1.2.2"
 pytest-custom-exit-code = {git = "https://github.com/GregaVrbancic/pytest-custom_exit_code.git"}
+bandit = "<1.7.3"

--- a/examples/log_results.py
+++ b/examples/log_results.py
@@ -15,6 +15,6 @@ from niapy.algorithms.basic import DifferentialEvolution
 task = Task(max_evals=10000, problem=Sphere(dimension=10))
 algo = DifferentialEvolution(population_size=40, crossover_probability=0.9, differential_weight=0.5)
 best = algo.run(task)
-evals, x_f = task.return_conv()
+evals, x_f = task.convergence_data()
 print(evals)  # print function evaluations
 print(x_f)  # print values

--- a/examples/log_results.py
+++ b/examples/log_results.py
@@ -15,6 +15,6 @@ from niapy.algorithms.basic import DifferentialEvolution
 task = Task(max_evals=10000, problem=Sphere(dimension=10))
 algo = DifferentialEvolution(population_size=40, crossover_probability=0.9, differential_weight=0.5)
 best = algo.run(task)
-evals, x_f = task.convergence_data()
+evals, x_f = task.convergence_data(x_axis='evals')
 print(evals)  # print function evaluations
 print(x_f)  # print values

--- a/examples/run_cso.py
+++ b/examples/run_cso.py
@@ -15,4 +15,4 @@ algo = CatSwarmOptimization()
 best = algo.run(task=task)
 print('%s -> %s' % (best[0], best[1]))
 # plot a convergence graph
-task.plot()
+task.plot_convergence(x_axis='evals')

--- a/niapy/task.py
+++ b/niapy/task.py
@@ -150,7 +150,6 @@ class Task:
             self.fitness_evals.append(x_f)
             if self.enable_logging:
                 logger.info('evals:%d => %s' % (self.evals, self.x_f))
-
         return x_f
 
     def is_feasible(self, x):

--- a/niapy/task.py
+++ b/niapy/task.py
@@ -202,14 +202,16 @@ class Task:
         else:  # x_axis == 'evals'
             r1, r2 = [], []
             for i, v in enumerate(self.n_evals):
-                r1.append(v), r2.append(self.fitness_evals[i])
+                r1.append(v)
+                r2.append(self.fitness_evals[i])
                 if i >= len(self.n_evals) - 1:
                     break
                 diff = self.n_evals[i + 1] - v
                 if diff <= 1:
                     continue
                 for j in range(diff - 1):
-                    r1.append(v + j + 1), r2.append(self.fitness_evals[i])
+                    r1.append(v + j + 1)
+                    r2.append(self.fitness_evals[i])
             return np.array(r1), np.array(r2)
 
     def plot_convergence(self, x_axis='iters', title='Convergence Graph'):
@@ -221,7 +223,7 @@ class Task:
 
         """
         x, fitness = self.convergence_data(x_axis)
-        fig, ax = plt.subplots()
+        _, ax = plt.subplots()
         ax.plot(x, fitness)
         ax.xaxis.set_major_locator(ticker.MaxNLocator(integer=True))
         if x_axis == 'iters':

--- a/niapy/task.py
+++ b/niapy/task.py
@@ -99,7 +99,8 @@ class Task:
         self.max_evals = max_evals
         self.max_iters = max_iters
         self.n_evals = []
-        self.x_f_vals = []
+        self.fitness_evals = []  # fitness improvements at self.n_evals evaluations
+        self.fitness_iters = []  # best fitness at each iteration
 
     def repair(self, x, rng=None):
         r"""Repair solution and put the solution in the random position inside of the bounds of problem.
@@ -123,6 +124,7 @@ class Task:
 
     def next_iter(self):
         r"""Increments the number of algorithm iterations."""
+        self.fitness_iters.append(self.x_f)
         self.iters += 1
 
     def eval(self, x):
@@ -144,7 +146,7 @@ class Task:
         if x_f < self.x_f * self.optimization_type.value:
             self.x_f = x_f * self.optimization_type.value
             self.n_evals.append(self.evals)
-            self.x_f_vals.append(x_f)
+            self.fitness_evals.append(x_f)
             if self.enable_logging:
                 logger.info('evals:%d => %s' % (self.evals, self.x_f))
 
@@ -182,32 +184,48 @@ class Task:
         self.next_iter()
         return r
 
-    def return_conv(self):
-        r"""Get values of x and y axis for plotting covariance graph.
+    def convergence_data(self, x_axis='iters'):
+        r"""Get values of x and y-axis for plotting covariance graph.
+
+        Args:
+            x_axis (Literal['iters', 'evals']): Quantity to be displayed on the x-axis. Either 'iters' or 'evals'.
 
         Returns:
-            Tuple[List[int], List[float]]:
-                1. List of ints of function evaluations.
-                2. List of ints of function/fitness values.
+            Tuple[np.ndarray, np.ndarray]:
+                1. array  of function evaluations.
+                2. array of fitness values.
 
         """
-        r1, r2 = [], []
-        for i, v in enumerate(self.n_evals):
-            r1.append(v), r2.append(self.x_f_vals[i])
-            if i >= len(self.n_evals) - 1:
-                break
-            diff = self.n_evals[i + 1] - v
-            if diff <= 1:
-                continue
-            for j in range(diff - 1):
-                r1.append(v + j + 1), r2.append(self.x_f_vals[i])
-        return r1, r2
+        if x_axis == 'iters':
+            return np.arange(self.iters), np.array(self.fitness_iters)
+        else:  # x_axis == 'evals'
+            r1, r2 = [], []
+            for i, v in enumerate(self.n_evals):
+                r1.append(v), r2.append(self.fitness_evals[i])
+                if i >= len(self.n_evals) - 1:
+                    break
+                diff = self.n_evals[i + 1] - v
+                if diff <= 1:
+                    continue
+                for j in range(diff - 1):
+                    r1.append(v + j + 1), r2.append(self.fitness_evals[i])
+            return np.array(r1), np.array(r2)
 
-    def plot(self):
-        """Plot a simple convergence graph."""
-        fess, fitness = self.return_conv()
-        plt.plot(fess, fitness)
-        plt.xlabel('Function Evaluations')
+    def plot_convergence(self, x_axis='iters', title='Convergence Graph'):
+        """Plot a simple convergence graph.
+
+        Args:
+            x_axis (Literal['iters', 'evals']): Quantity to be displayed on the x-axis. Either 'iters' or 'evals'.
+            title (str): Title of the graph.
+
+        """
+        x, fitness = self.convergence_data(x_axis)
+        plt.plot(x, fitness)
+        if x_axis == 'iters':
+            plt.xlabel('Iterations')
+            plt.xticks(range(self.iters))
+        else:
+            plt.xlabel('Fitness Evaluations')
         plt.ylabel('Fitness')
-        plt.title('Convergence Graph')
+        plt.title(title)
         plt.show()

--- a/niapy/task.py
+++ b/niapy/task.py
@@ -7,6 +7,7 @@ from enum import Enum
 
 import numpy as np
 from matplotlib import pyplot as plt
+import matplotlib.ticker as ticker
 from niapy.problems import Problem
 from niapy.util.repair import limit
 from niapy.util.factory import get_problem
@@ -220,10 +221,11 @@ class Task:
 
         """
         x, fitness = self.convergence_data(x_axis)
-        plt.plot(x, fitness)
+        fig, ax = plt.subplots()
+        ax.plot(x, fitness)
+        ax.xaxis.set_major_locator(ticker.MaxNLocator(integer=True))
         if x_axis == 'iters':
             plt.xlabel('Iterations')
-            plt.xticks(range(self.iters))
         else:
             plt.xlabel('Fitness Evaluations')
         plt.ylabel('Fitness')

--- a/niapy/tests/test_task.py
+++ b/niapy/tests/test_task.py
@@ -145,7 +145,7 @@ class TaskTestCase(TestCase):
         for i in range(self.nFES):
             x = np.full(self.D, 10 - i)
             r1.append(i + 1), r2.append(self.task.eval(x))
-        t_r1, t_r2 = self.task.return_conv()
+        t_r1, t_r2 = self.task.convergence_data()
         self.assertTrue(np.array_equal(r1, t_r1))
         self.assertTrue(np.array_equal(r2, t_r2))
 
@@ -154,6 +154,6 @@ class TaskTestCase(TestCase):
         for i in range(self.nFES):
             x = np.full(self.D, 10 - i if i not in (3, 4, 5) else 4)
             r1.append(i + 1), r2.append(self.task.eval(x))
-        t_r1, t_r2 = self.task.return_conv()
+        t_r1, t_r2 = self.task.convergence_data()
         self.assertTrue(np.array_equal(r2, t_r2))
         self.assertTrue(np.array_equal(r1, t_r1))

--- a/niapy/tests/test_task.py
+++ b/niapy/tests/test_task.py
@@ -145,7 +145,7 @@ class TaskTestCase(TestCase):
         for i in range(self.nFES):
             x = np.full(self.D, 10 - i)
             r1.append(i + 1), r2.append(self.task.eval(x))
-        t_r1, t_r2 = self.task.convergence_data()
+        t_r1, t_r2 = self.task.convergence_data(x_axis='evals')
         self.assertTrue(np.array_equal(r1, t_r1))
         self.assertTrue(np.array_equal(r2, t_r2))
 
@@ -154,6 +154,6 @@ class TaskTestCase(TestCase):
         for i in range(self.nFES):
             x = np.full(self.D, 10 - i if i not in (3, 4, 5) else 4)
             r1.append(i + 1), r2.append(self.task.eval(x))
-        t_r1, t_r2 = self.task.convergence_data()
+        t_r1, t_r2 = self.task.convergence_data(x_axis='evals')
         self.assertTrue(np.array_equal(r2, t_r2))
         self.assertTrue(np.array_equal(r1, t_r1))

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ setuptools.setup(
         'astroid >= 2.0.4',
         'pytest ~= 3.7.1',
         'coverage ~= 4.4.2',
-        'coverage-space ~= 1.0.2'
+        'coverage-space ~= 1.0.2',
+        'bandit < 1.7.3'
     ],
     install_requires=[
         'numpy >= 1.17.0',


### PR DESCRIPTION
### Summary

- Modified convergence plotting so that a user can control whether generations or evaluations will be on the x axis of the graph.
In case of generations/iterations the best global fitness at each iteration is plotted. In case of evaluations, we have the number of evaluations at which improvements were made on the x axis and the fitness values at those points on the y axis.
- Renamed `task.plot()` to `task.plot_convergence()`.
- Renamed `task.return_conv()` to `task.convergence_data()`.
- Both `task.convergence_data()` and `task.plot_convergence()` have an argument `x_axis` which can be either 'evals' or 'iters' and it controls what goes on the x_axis. The default is 'iters'. `task.plot_convergence()` has an aditional parameter `title`, to set the title of the matplotlib graph.
- `task.convergence_data()` now returns a tuple of numpy arrays instead of python lists.
- Also fixed a flake8 dependency issue which caused it to crash.
