### PR TITLE
fixed exporting to excel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     env:
       MPLBACKEND: "agg"
       PIPENV_VENV_IN_PROJECT: 1

--- a/niapy/runner.py
+++ b/niapy/runner.py
@@ -85,21 +85,16 @@ class Runner:
         dataframe.to_json(self.__generate_export_name("json"))
         logger.info("Export to JSON file completed!")
 
-    def _export_to_xls(self):
-        dataframe = pd.DataFrame.from_dict(self.results)
-        dataframe.to_excel(self.__generate_export_name("xls"))
-        logger.info("Export to XLS completed!")
-
     def __export_to_xlsx(self):
         dataframe = pd.DataFrame.from_dict(self.results)
-        dataframe.to_excel(self.__generate_export_name("xslx"))
+        dataframe.to_excel(self.__generate_export_name("xlsx"))
         logger.info("Export to XLSX file completed!")
 
     def run(self, export="dataframe", verbose=False):
         """Execute runner.
 
         Args:
-            export (str): Takes export type (e.g. dataframe, json, xls, xlsx) (default: "dataframe")
+            export (str): Takes export type (e.g. dataframe, json, excel) (default: "dataframe")
             verbose (bool): Switch for verbose logging (default: {False})
 
         Returns:
@@ -143,9 +138,7 @@ class Runner:
             self.__export_to_dataframe_pickle()
         elif export == "json":
             self.__export_to_json()
-        elif export == "xsl":
-            self._export_to_xls()
-        elif export == "xlsx":
+        elif export == "excel":
             self.__export_to_xlsx()
         else:
             raise TypeError("Passed export type %s is not supported!", export)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import setuptools
 
 
 PACKAGE_NAME = 'niapy'
-MINIMUM_PYTHON_VERSION = (3, 6)
+MINIMUM_PYTHON_VERSION = (3, 8)
 
 
 def check_python_version():


### PR DESCRIPTION
### Summary
- Fixed #396 
- Removed support for exporting to the Excel 97 - Excel 2003 format ".xls"
- Renamed export option `xlsx` to `excel`
- Dropped python 3.6 and 3.7 from CI and added python 3.11 (should probably be a separate pr)
