### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "monthly"
+    # Disable automatic updates for docs dependencies
+    open-pull-requests-limit: 0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ certifi==2023.7.22
     # via requests
 charset-normalizer==3.3.1
     # via requests
-docutils==0.20.1
+docutils==0.18.1
     # via
     #   sphinx
     #   sphinx-rtd-theme


### PR DESCRIPTION
### Summary

- Dependabot should now ignore updates in the docs directory
- Pinned the dependencies in docs/requirements.txt
