### PR TITLE
Fix docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,28 +8,64 @@ alabaster==0.7.13
     # via sphinx
 babel==2.13.1
     # via sphinx
-certifi==2023.11.17
+certifi==2023.7.22
     # via requests
 charset-normalizer==3.3.1
     # via requests
+contourpy==1.2.0
+    # via matplotlib
+cycler==0.12.1
+    # via matplotlib
 docutils==0.18.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
+et-xmlfile==1.1.0
+    # via openpyxl
+fonttools==4.48.1
+    # via matplotlib
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
 jinja2==3.1.2
     # via sphinx
+kiwisolver==1.4.5
+    # via matplotlib
 markupsafe==2.1.3
     # via jinja2
+matplotlib==3.8.2
+    # via -r requirements.in
+numpy==1.26.4
+    # via
+    #   -r requirements.in
+    #   contourpy
+    #   matplotlib
+    #   pandas
+openpyxl==3.1.2
+    # via -r requirements.in
 packaging==23.2
-    # via sphinx
+    # via
+    #   matplotlib
+    #   sphinx
+pandas==2.2.0
+    # via -r requirements.in
+pillow==10.2.0
+    # via matplotlib
 pygments==2.16.1
     # via sphinx
+pyparsing==3.1.1
+    # via matplotlib
+python-dateutil==2.8.2
+    # via
+    #   matplotlib
+    #   pandas
+pytz==2024.1
+    # via pandas
 requests==2.31.0
     # via sphinx
+six==1.16.0
+    # via python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
 sphinx==7.2.6
@@ -58,5 +94,7 @@ sphinxcontrib-qthelp==1.0.6
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
-urllib3==2.1.0
+tzdata==2023.4
+    # via pandas
+urllib3==2.0.7
     # via requests


### PR DESCRIPTION
### Summary

The docs weren't building on readthedocs because the project's dependencies weren't listed in docs/requirements.txt. I've added these dependencies to the requirements file.